### PR TITLE
BugFix: Some classroom's name may not contain a number

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import sys
 import os
 
 # regular expression for extracting subject information
-SUBJECT_REGEX = re.compile(r'\[(\w+)\](.+)｛(\d+-\d+)周\[教师:(\w+),地点:(\d+-\d+)\]｝')
+SUBJECT_REGEX = re.compile(r'\[(\w+)\](.+)｛(\d+-\d+)周\[教师:(\w+),地点:(.+)\]｝')
 
 # subject information
 class Subject(object):


### PR DESCRIPTION
有的课程地点的格式不是“3-123”，例如

```[西土城]艺术体操｛3-18周[教师:郭玥含,地点:体育馆三层]``` 的 ```体育馆三层``` 无法匹配正则```(\d+-\d+)```

下图是在正则匹配之前print了一下```Subject```中```__init__```函数的```str```

![dbg](https://github.com/kahakaha/bupt-kb-helper/assets/56995506/b59e6a93-31fa-4107-beaa-ed42f3a3fca0)

PS：感觉把```(\d+-\d+)```改为```(.+)```应该不会匹配到无效的信息吧

