### PR TITLE
fix: parse a subject's location correctly (#3)

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import sys
 import os
 
 # regular expression for extracting subject information
-SUBJECT_REGEX = re.compile(r'\[(\w+)\](.+)｛(\d+-\d+)周\[教师:(\w+),地点:(\d+-\d+)\]｝')
+SUBJECT_REGEX = re.compile(r'\[(\w+)\](.+)｛(\d+-\d+)周\[教师:(\w+),地点:(.+)\]｝')
 
 # subject information
 class Subject(object):


### PR DESCRIPTION
解决了当课程地点不是教室号，正则式无法匹配的问题